### PR TITLE
Make sure fzf uses fish to preview environment variables

### DIFF
--- a/functions/__fzf_search_shell_variables.fish
+++ b/functions/__fzf_search_shell_variables.fish
@@ -1,7 +1,7 @@
 function __fzf_search_shell_variables --description "Search and inspect shell variables using fzf. Insert the selected variable into the commandline at the cursor."
-    # Make sure that fzf uses the fish shell when it calls __echo_value_or_print_message, which
+    # Make sure that fzf uses fish to execute __echo_value_or_print_message, which
     # is an autoloaded fish function so doesn't exist in other shells.
-    # Using the local flag so that it does not clobber SHELL outside of this function
+    # Using --local so that it does not clobber SHELL outside of this function.
     set --local --export SHELL (which fish)
 
     # Pipe the names of all shell variables to fzf.

--- a/functions/__fzf_search_shell_variables.fish
+++ b/functions/__fzf_search_shell_variables.fish
@@ -1,4 +1,9 @@
 function __fzf_search_shell_variables --description "Search and inspect shell variables using fzf. Insert the selected variable into the commandline at the cursor."
+    # Make sure that fzf uses the fish shell when it calls __echo_value_or_print_message, which
+    # is an autoloaded fish function so doesn't exist in other shells.
+    # Using the local flag so that it does not clobber SHELL outside of this function
+    set --local --export SHELL (which fish)
+
     # Pipe the names of all shell variables to fzf.
     # Attempt to display the value of the selected variable in fzf's preview window.
     # Non-exported variables will not be accessible to the fzf process, in which case


### PR DESCRIPTION
Resolves #10 
To repro the problem this PR is trying to address
1. set your SHELL variable to a different shell, e.g. `zsh`
2. execute the browse shell variable functionality
3. scroll over a variable
4. should see `zsh:1: command not found: __echo_or_print_message`, which is an indication that fzf is using the shell specified in SHELL to call the preview command
