### PR TITLE
Show command timestamps when searching command history

### DIFF
--- a/functions/__fzf_search_history.fish
+++ b/functions/__fzf_search_history.fish
@@ -8,7 +8,7 @@ function __fzf_search_history --description "Search command history using fzf. R
     )
 
     if test $status -eq 0
-        set command_selected (string split --max 1 " | " $command_with_ts)[]
+        set command_selected (string split --max 1 " | " $command_with_ts)[2]
         commandline --replace $command_selected
     end
 

--- a/functions/__fzf_search_history.fish
+++ b/functions/__fzf_search_history.fish
@@ -1,9 +1,10 @@
 # originally implemented and transposed from https://github.com/patrickf3139/dotfiles/pull/11
 function __fzf_search_history --description "Search command history using fzf. Replace the commandline with the selected command."
+    # history merge incorporates history changes from other fish sessions
     history merge
     set command_with_ts (
         # Reference https://devhints.io/strftime to understand strftime format symbols
-        history --null --show-time="%m/%e %I:%M %p | " |
+        history --null --show-time="%m/%e %H:%M:%S | " |
         fzf --read0 --tiebreak=index --query=(commandline)
     )
 

--- a/functions/__fzf_search_history.fish
+++ b/functions/__fzf_search_history.fish
@@ -1,12 +1,14 @@
 # originally implemented and transposed from https://github.com/patrickf3139/dotfiles/pull/11
 function __fzf_search_history --description "Search command history using fzf. Replace the commandline with the selected command."
     history merge
-    set command_selected (
-        history --null |
+    set command_with_ts (
+        # Reference https://devhints.io/strftime to understand strftime format symbols
+        history --null --show-time="%m/%e %I:%M %p | " |
         fzf --read0 --tiebreak=index --query=(commandline)
     )
 
     if test $status -eq 0
+        set command_selected (string split --max 1 " | " $command_with_ts)[]
         commandline --replace $command_selected
     end
 


### PR DESCRIPTION
Making full use of the timestamp option for https://fishshell.com/docs/current/cmds/history.html
New log line example: `07/20 20:18:12 | help bind`.