### PR TITLE
Set keybindings when in vi mode

### DIFF
--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -6,7 +6,7 @@ if not set --query fzf_fish_custom_keybindings
     bind \cr '__fzf_search_history'
     bind \cv '__fzf_search_shell_variables'
 
-    # also set up the same keybindings for insert mode if the user is using fish_vi_key_bindings
+    # set up the same keybindings for insert mode if using fish_vi_key_bindings
     if [ $fish_key_bindings = 'fish_vi_key_bindings' ]
         bind --mode insert \cf '__fzf_search_current_dir'
         bind --mode insert \cl '__fzf_search_git_log'

--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -5,6 +5,14 @@ if not set --query fzf_fish_custom_keybindings
     bind \cl '__fzf_search_git_log'
     bind \cr '__fzf_search_history'
     bind \cv '__fzf_search_shell_variables'
+
+    # also set up the same keybindings for insert mode if the user is using fish_vi_key_bindings
+    if [ $fish_key_bindings = 'fish_vi_key_bindings' ]
+        bind --mode insert \cf '__fzf_search_current_dir'
+        bind --mode insert \cl '__fzf_search_git_log'
+        bind --mode insert \cr '__fzf_search_history'
+        bind --mode insert \cv '__fzf_search_shell_variables'
+    end
 end
 
 # If FZF_DEFAULT_OPTS is not set, then set some sane defaults. This also affects fzf outside of this plugin.

--- a/functions/uninstall.fish
+++ b/functions/uninstall.fish
@@ -1,9 +1,9 @@
 #!/usr/bin/env fish
 if not set --query fzf_fish_custom_keybindings
-    bind --erase \cf
-    bind --erase \cl
-    bind --erase \cr
-    bind --erase \cv
+    bind --erase --all \cf
+    bind --erase --all \cl
+    bind --erase --all \cr
+    bind --erase --all \cv
 
     set_color --italics cyan
     echo "fzf_fish_integration key kindings removed"


### PR DESCRIPTION
The default keybindings were only being set up for default mode. Now, also set up the default keybindings for insert mode if the user is using fish_vi_key_bindings.
Resolves #13 